### PR TITLE
chore: peer-discovery not using peer-info

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
   "devDependencies": {
     "aegir": "^21.4.5",
     "chai": "^4.2.0",
+    "chai-bytes": "^0.1.2",
     "dirty-chai": "^2.0.1",
-    "libp2p-interfaces": "^0.2.7",
+    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x",
     "p-defer": "^3.0.0",
     "p-wait-for": "^3.1.0",
     "sinon": "^9.0.1"
@@ -52,7 +53,6 @@
     "emittery": "^0.6.0",
     "multiaddr": "^7.4.3",
     "peer-id": "^0.13.11",
-    "peer-info": "^0.17.5",
     "protons": "^1.0.2"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai": "^4.2.0",
     "chai-bytes": "^0.1.2",
     "dirty-chai": "^2.0.1",
-    "libp2p-interfaces": "libp2p/js-interfaces#v0.3.x",
+    "libp2p-interfaces": "^0.3.0",
     "p-defer": "^3.0.0",
     "p-wait-for": "^3.1.0",
     "sinon": "^9.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,6 @@ class PubsubPeerDiscovery extends Emittery {
    * @constructor
    * @param {Libp2p} param0.libp2p Our libp2p node
    * @param {number} [param0.interval = 10000] How often (ms) we should broadcast our infos
-   * @param {Array<Multiaddr>} param0.multiaddrs Multiaddrs used by the node to listen.
    * @param {Array<string>} [param0.topics = PubsubPeerDiscovery.TOPIC] What topics to subscribe to. If set, the default will NOT be used.
    * @param {boolean} [param0.listenOnly = false] If true, we will not broadcast our peer data
    */
@@ -38,12 +37,10 @@ class PubsubPeerDiscovery extends Emittery {
     libp2p,
     interval = 10000,
     topics,
-    multiaddrs = [],
     listenOnly = false
   }) {
     super()
     this.libp2p = libp2p
-    this.multiaddrs = multiaddrs
     this.interval = interval
     this._intervalId = null
     this._listenOnly = listenOnly
@@ -101,7 +98,7 @@ class PubsubPeerDiscovery extends Emittery {
   _broadcast () {
     const peer = {
       publicKey: this.libp2p.peerId.pubKey.bytes,
-      addrs: this.multiaddrs.map(ma => ma.buffer)
+      addrs: this.libp2p.transportManager.getAddrs().map(ma => ma.buffer)
     }
 
     const encodedPeer = PB.Peer.encode(peer)
@@ -132,6 +129,12 @@ class PubsubPeerDiscovery extends Emittery {
     }
   }
 
+  /**
+   * Emit discovered peers.
+   * @private
+   * @param {PeerId} peerId
+   * @param {Array<Buffer>} addrs
+   */
   _onNewPeer (peerId, addrs) {
     if (!this._intervalId) return
 

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -5,17 +5,17 @@ const tests = require('libp2p-interfaces/src/peer-discovery/tests')
 const PubsubPeerDiscovery = require('../src')
 
 const PeerID = require('peer-id')
-const PeerInfo = require('peer-info')
 
 describe('compliance tests', () => {
+  let intervalId
   tests({
     async setup () {
       const peerId = await PeerID.create({ bits: 512 })
-      const peerInfo = new PeerInfo(peerId)
       await new Promise(resolve => setTimeout(resolve, 10))
-      return new PubsubPeerDiscovery({
+
+      const pubsubDiscovery = new PubsubPeerDiscovery({
         libp2p: {
-          peerInfo,
+          peerId,
           pubsub: {
             subscribe: () => {},
             unsubscribe: () => {},
@@ -23,9 +23,16 @@ describe('compliance tests', () => {
           }
         }
       })
+
+      intervalId = setInterval(() => {
+        pubsubDiscovery._onNewPeer(peerId, ['/ip4/166.10.1.2/tcp/80'])
+      }, 1000)
+
+      return pubsubDiscovery
     },
     async teardown () {
       await new Promise(resolve => setTimeout(resolve, 10))
+      clearInterval(intervalId)
     }
   })
 })

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -15,6 +15,9 @@ describe('compliance tests', () => {
 
       const pubsubDiscovery = new PubsubPeerDiscovery({
         libp2p: {
+          transportManager: {
+            getAddrs: () => []
+          },
           peerId,
           pubsub: {
             subscribe: () => {},

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -26,6 +26,9 @@ describe('Pubsub Peer Discovery', () => {
 
     mockLibp2p = {
       peerId,
+      transportManager: {
+        getAddrs: () => [listeningMultiaddrs]
+      },
       pubsub: {
         subscribe: () => {},
         publish: () => {},
@@ -40,7 +43,7 @@ describe('Pubsub Peer Discovery', () => {
   })
 
   it('should not discover self', async () => {
-    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p, multiaddrs: [listeningMultiaddrs] })
+    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p })
     sinon.spy(mockLibp2p.pubsub, 'publish')
     discovery._broadcast()
     expect(mockLibp2p.pubsub.publish.callCount).to.equal(1)
@@ -62,7 +65,7 @@ describe('Pubsub Peer Discovery', () => {
   })
 
   it('should be able to encode/decode a message', async () => {
-    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p, multiaddrs: [listeningMultiaddrs] })
+    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p })
     discovery.start()
 
     const peerId = await PeerID.create({ bits: 512 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,27 +3,29 @@
 
 const chai = require('chai')
 chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
 const { expect } = chai
 const sinon = require('sinon')
 const defer = require('p-defer')
 const pWaitFor = require('p-wait-for')
 
+const multiaddr = require('multiaddr')
 const PeerID = require('peer-id')
-const PeerInfo = require('peer-info')
 
 const PubsubPeerDiscovery = require('../src')
 const PB = require('../src/peer.proto')
+
+const listeningMultiaddrs = multiaddr('/ip4/127.0.0.1/tcp/9000/ws')
 
 describe('Pubsub Peer Discovery', () => {
   let mockLibp2p
   let discovery
 
   before(async () => {
-    const peerInfo = await PeerInfo.create()
-    peerInfo.multiaddrs.add('/ip4/127.0.0.1/tcp/9000/ws')
+    const peerId = await PeerID.create()
 
     mockLibp2p = {
-      peerInfo,
+      peerId,
       pubsub: {
         subscribe: () => {},
         publish: () => {},
@@ -38,7 +40,7 @@ describe('Pubsub Peer Discovery', () => {
   })
 
   it('should not discover self', async () => {
-    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p })
+    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p, multiaddrs: [listeningMultiaddrs] })
     sinon.spy(mockLibp2p.pubsub, 'publish')
     discovery._broadcast()
     expect(mockLibp2p.pubsub.publish.callCount).to.equal(1)
@@ -46,10 +48,10 @@ describe('Pubsub Peer Discovery', () => {
     const [topic, encodedPeer] = mockLibp2p.pubsub.publish.getCall(0).args
     const peer = PB.Peer.decode(encodedPeer)
     const peerId = await PeerID.createFromPubKey(peer.publicKey)
-    expect(peerId.equals(mockLibp2p.peerInfo.id)).to.equal(true)
+    expect(peerId.equals(mockLibp2p.peerId)).to.equal(true)
     expect(peer.addrs).to.have.length(1)
     peer.addrs.forEach((addr) => {
-      expect(mockLibp2p.peerInfo.multiaddrs.has(addr)).to.equal(true)
+      expect(addr).to.equalBytes(listeningMultiaddrs.buffer)
     })
     expect(topic).to.equal(PubsubPeerDiscovery.TOPIC)
 
@@ -60,14 +62,20 @@ describe('Pubsub Peer Discovery', () => {
   })
 
   it('should be able to encode/decode a message', async () => {
-    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p })
+    discovery = new PubsubPeerDiscovery({ libp2p: mockLibp2p, multiaddrs: [listeningMultiaddrs] })
+    discovery.start()
+
     const peerId = await PeerID.create({ bits: 512 })
-    const expectedPeerInfo = new PeerInfo(peerId)
-    expectedPeerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/8080/ws')
-    expectedPeerInfo.multiaddrs.add('/ip4/0.0.0.0/tcp/8081/ws')
+    const expectedPeerData = {
+      id: peerId,
+      multiaddrs: [
+        '/ip4/0.0.0.0/tcp/8080/ws',
+        '/ip4/0.0.0.0/tcp/8081/ws'
+      ]
+    }
     const peer = {
       publicKey: peerId.pubKey.bytes,
-      addrs: expectedPeerInfo.multiaddrs.toArray().map(ma => ma.buffer)
+      addrs: expectedPeerData.multiaddrs.map(ma => multiaddr(ma).buffer)
     }
 
     const deferred = defer()
@@ -80,9 +88,10 @@ describe('Pubsub Peer Discovery', () => {
     await discovery._onMessage({ data: encodedPeer, topicIDs: [PubsubPeerDiscovery.TOPIC] })
 
     const discoveredPeer = await deferred.promise
-    expect(discoveredPeer.id.equals(expectedPeerInfo.id)).to.equal(true)
-    expectedPeerInfo.multiaddrs.forEach(addr => {
-      expect(discoveredPeer.multiaddrs.has(addr)).to.equal(true)
+    expect(discoveredPeer.id.equals(expectedPeerData.id)).to.equal(true)
+
+    discoveredPeer.multiaddrs.forEach(addr => {
+      expect(expectedPeerData.multiaddrs.includes(addr.toString())).to.equal(true)
     })
   })
 


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR changes the `peer-discovery` interface to emit an object containing an `id` property and a `multiaddrs` property.

This PR also adds the new `peer-discovery` interface tests

BREAKING CHANGE: peer event emits an object with id and multiaddr instead of a peer-info

Needs:

- [x] [libp2p/js-libp2p-interfaces#41](https://github.com/libp2p/js-libp2p-interfaces/pull/41)