### PR TITLE
chore: use address manager

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ class PubsubPeerDiscovery extends Emittery {
   _broadcast () {
     const peer = {
       publicKey: this.libp2p.peerId.pubKey.bytes,
-      addrs: this.libp2p.transportManager.getAddrs().map(ma => ma.buffer)
+      addrs: this.libp2p.multiaddrs.map(ma => ma.buffer)
     }
 
     const encodedPeer = PB.Peer.encode(peer)

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -15,9 +15,7 @@ describe('compliance tests', () => {
 
       const pubsubDiscovery = new PubsubPeerDiscovery({
         libp2p: {
-          transportManager: {
-            getAddrs: () => []
-          },
+          multiaddrs: [],
           peerId,
           pubsub: {
             subscribe: () => {},

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -26,9 +26,7 @@ describe('Pubsub Peer Discovery', () => {
 
     mockLibp2p = {
       peerId,
-      transportManager: {
-        getAddrs: () => [listeningMultiaddrs]
-      },
+      multiaddrs: [listeningMultiaddrs],
       pubsub: {
         subscribe: () => {},
         publish: () => {},


### PR DESCRIPTION
In the context of the new Address Manager implemented on [libp2p/js-libp2p#612](https://github.com/libp2p/js-libp2p/pull/612), we should get the advertised multiaddrs here.