### PR TITLE
fix: add support for multiaddrs 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "emittery": "^0.6.0",
-    "multiaddr": "^7.4.3",
+    "multiaddr": "^8.0.0",
     "peer-id": "^0.13.11",
     "protons": "^1.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ class PubsubPeerDiscovery extends Emittery {
   _broadcast () {
     const peer = {
       publicKey: this.libp2p.peerId.pubKey.bytes,
-      addrs: this.libp2p.multiaddrs.map(ma => ma.buffer)
+      addrs: this.libp2p.multiaddrs.map(ma => ma.bytes)
     }
 
     const encodedPeer = PB.Peer.encode(peer)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -52,7 +52,7 @@ describe('Pubsub Peer Discovery', () => {
     expect(peerId.equals(mockLibp2p.peerId)).to.equal(true)
     expect(peer.addrs).to.have.length(1)
     peer.addrs.forEach((addr) => {
-      expect(addr).to.equalBytes(listeningMultiaddrs.buffer)
+      expect(addr).to.equalBytes(listeningMultiaddrs.bytes)
     })
     expect(topic).to.equal(PubsubPeerDiscovery.TOPIC)
 
@@ -76,7 +76,7 @@ describe('Pubsub Peer Discovery', () => {
     }
     const peer = {
       publicKey: peerId.pubKey.bytes,
-      addrs: expectedPeerData.multiaddrs.map(ma => multiaddr(ma).buffer)
+      addrs: expectedPeerData.multiaddrs.map(ma => multiaddr(ma).bytes)
     }
 
     const deferred = defer()


### PR DESCRIPTION
libp2p 0.29.0 uses multiaddrs 8.0.0 which has a breaking change: https://github.com/multiformats/js-multiaddr/pull/140#issue-464610116

Changed references to `buffer` with `bytes`. 

PS: Haven't bumped the version, is up to you if you end up merging