### PR TITLE
fix: do pubsub operations after start

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "protobufjs": "^6.11.2"
   },
   "devDependencies": {
-    "@libp2p/interface-compliance-tests": "^1.1.18",
+    "@libp2p/interface-compliance-tests": "^1.1.19",
     "@libp2p/peer-id-factory": "^1.0.8",
     "aegir": "^36.2.3",
     "p-defer": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,13 +68,29 @@ export class PubSubPeerDiscovery extends EventEmitter<PeerDiscoveryEvents> imple
     return this.intervalId != null
   }
 
+  start () {
+
+  }
+
   /**
    * Subscribes to the discovery topic on `libp2p.pubsub` and performs a broadcast
    * immediately, and every `this.interval`
    */
-  start () {
+  afterStart () {
     if (this.intervalId != null) {
       return
+    }
+
+    const pubsub = this.components.getPubSub()
+
+    if (pubsub == null) {
+      throw new Error('PubSub not configured')
+    }
+
+    // Subscribe to pubsub
+    for (const topic of this.topics) {
+      pubsub.subscribe(topic)
+      pubsub.addEventListener(topic, this._onMessage)
     }
 
     // Don't broadcast if we are only listening
@@ -89,20 +105,6 @@ export class PubSubPeerDiscovery extends EventEmitter<PeerDiscoveryEvents> imple
     this.intervalId = setInterval(() => {
       this._broadcast()
     }, this.interval)
-  }
-
-  afterStart () {
-    const pubsub = this.components.getPubSub()
-
-    if (pubsub == null) {
-      throw new Error('PubSub not configured')
-    }
-
-    // Subscribe to pubsub
-    for (const topic of this.topics) {
-      pubsub.subscribe(topic)
-      pubsub.addEventListener(topic, this._onMessage)
-    }
   }
 
   beforeStop () {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -51,6 +51,7 @@ describe('PubSub Peer Discovery', () => {
     discovery = new PubSubPeerDiscovery()
     discovery.init(components)
     await discovery.start()
+    await discovery.afterStart()
 
     expect(mockPubsub.dispatchEvent.callCount).to.equal(1)
     discovery._broadcast()
@@ -87,6 +88,7 @@ describe('PubSub Peer Discovery', () => {
     discovery = new PubSubPeerDiscovery()
     discovery.init(components)
     await discovery.start()
+    await discovery.afterStart()
 
     const peerId = await createEd25519PeerId()
     const expectedPeerData: PeerData = {


### PR DESCRIPTION
To ensure pubsub is started before we interact, move the broadcast start to afterStart