### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # @libp2p/pubsub-peer-discovery <!-- omit in toc -->
 
 [![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
-[![IRC](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
 [![codecov](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-pubsub-peer-discovery.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-pubsub-peer-discovery)
-[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-interfaces/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-pubsub-peer-discovery/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/workflow/status/libp2p/js-libp2p-pubsub-peer-discovery/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/libp2p/js-libp2p-pubsub-peer-discovery/actions/workflows/js-test-and-release.yml)
 
 > A libp2p module that uses pubsub for mdns like peer discovery
 
@@ -22,7 +21,7 @@
     - [Default Topic](#default-topic)
 - [Contribute](#contribute)
 - [License](#license)
-- [Contribution](#contribution)
+- [Contribute](#contribute-1)
 
 ## Install
 
@@ -55,25 +54,25 @@ If you are only interested in listening to the global pubsub topic the minimal c
 
 ```js
 import { createLibp2p } from 'libp2p'
-import { Websockets } from '@libp2p/websockets'
-import { Mplex } from '@libp2p/mplex'
-import { Noise } from '@libp2p/noise'
-import GossipSub from 'libp2p-gossipsub'
-import { PubSubPeerDiscovery } from '@libp2p/pubsub-peer-discovery'
+import { websockets } from '@libp2p/websockets'
+import { mplex } from '@libp2p/mplex'
+import { noise } from '@chainsafe/libp2p-noise'
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
+import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery'
 
 const node = await createLibp2p({
   transports: [
-    new Websockets()
+    websockets()
   ], // Any libp2p transport(s) can be used
   streamMuxers: [
-    new Mplex()
+    mplex()
   ],
   connectionEncryption: [
-    new Noise()
+    noise()
   ],
   pubsub: new GossipSub(), // Can also be `libp2p-floodsub` if desired
   peerDiscovery: [
-    new PubSubPeerDiscovery()
+    pubsubPeerDiscovery()
   ]
 })
 ```
@@ -95,7 +94,7 @@ const topics = [
 const node = await createLibp2p({
   // ...
   peerDiscovery: [
-    new PubSubPeerDiscovery({
+    pubsubPeerDiscovery({
       interval: 10000,
       topics: topics, // defaults to ['_peer-discovery._p2p._pubsub']
       listenOnly: false
@@ -131,6 +130,6 @@ Licensed under either of
 - Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
 
-## Contribution
+## Contribute
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/package.json
+++ b/package.json
@@ -143,24 +143,24 @@
     "release": "semantic-release"
   },
   "dependencies": {
-    "@libp2p/components": "^2.0.4",
     "@libp2p/interface-peer-discovery": "^1.0.1",
+    "@libp2p/interface-peer-id": "^1.0.5",
     "@libp2p/interface-peer-info": "^1.0.2",
-    "@libp2p/interface-pubsub": "^2.0.1",
+    "@libp2p/interface-pubsub": "^3.0.0",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",
     "@libp2p/peer-id": "^1.1.15",
-    "@multiformats/multiaddr": "^10.4.0",
-    "protons-runtime": "^3.1.0"
+    "@multiformats/multiaddr": "^11.0.5",
+    "protons-runtime": "^4.0.1"
   },
   "devDependencies": {
-    "@libp2p/interface-address-manager": "^1.0.2",
-    "@libp2p/interface-peer-discovery-compliance-tests": "^1.0.1",
+    "@libp2p/interface-address-manager": "^2.0.0",
+    "@libp2p/interface-peer-discovery-compliance-tests": "^2.0.0",
     "@libp2p/peer-id-factory": "^1.0.18",
     "aegir": "^37.2.0",
     "p-defer": "^4.0.0",
     "p-wait-for": "^5.0.0",
-    "protons": "^5.1.0",
+    "protons": "^6.0.0",
     "sinon": "^14.0.0",
     "ts-sinon": "^2.0.2"
   }

--- a/src/peer.proto
+++ b/src/peer.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
 message Peer {
-  required bytes publicKey = 0;
-  repeated bytes addrs = 1;
+  bytes publicKey = 1;
+  repeated bytes addrs = 2;
 }

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,5 +1,7 @@
 /* eslint-disable import/export */
+/* eslint-disable complexity */
 /* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -15,29 +17,25 @@ export namespace Peer {
 
   export const codec = (): Codec<Peer> => {
     if (_codec == null) {
-      _codec = message<Peer>((obj, writer, opts = {}) => {
+      _codec = message<Peer>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
-          writer.fork()
+          w.fork()
         }
 
-        if (obj.publicKey != null) {
-          writer.uint32(2)
-          writer.bytes(obj.publicKey)
-        } else {
-          throw new Error('Protocol error: required field "publicKey" was not found in object')
+        if (opts.writeDefaults === true || (obj.publicKey != null && obj.publicKey.byteLength > 0)) {
+          w.uint32(10)
+          w.bytes(obj.publicKey)
         }
 
         if (obj.addrs != null) {
           for (const value of obj.addrs) {
-            writer.uint32(10)
-            writer.bytes(value)
+            w.uint32(18)
+            w.bytes(value)
           }
-        } else {
-          throw new Error('Protocol error: required field "addrs" was not found in object')
         }
 
         if (opts.lengthDelimited !== false) {
-          writer.ldelim()
+          w.ldelim()
         }
       }, (reader, length) => {
         const obj: any = {
@@ -51,20 +49,16 @@ export namespace Peer {
           const tag = reader.uint32()
 
           switch (tag >>> 3) {
-            case 0:
+            case 1:
               obj.publicKey = reader.bytes()
               break
-            case 1:
+            case 2:
               obj.addrs.push(reader.bytes())
               break
             default:
               reader.skipType(tag & 7)
               break
           }
-        }
-
-        if (obj.publicKey == null) {
-          throw new Error('Protocol error: value for required field "publicKey" was not found in protobuf')
         }
 
         return obj


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs libp2p/js-libp2p-components#6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection