### PR TITLE
feat: Include protocols with PeerInfo broadcast

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-peer-info": "^1.0.2",
     "@libp2p/interface-pubsub": "^4.0.0",
+    "@libp2p/interface-internal": "^0.1.4",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",
     "@libp2p/peer-id": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type { Message, PubSub } from '@libp2p/interface-pubsub'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import { symbol } from '@libp2p/interface-peer-discovery'
 import type { AddressManager } from '@libp2p/interface-address-manager'
+import type { Registrar } from '@libp2p/interface-internal/registrar'
 import type { PeerId } from '@libp2p/interface-peer-id'
 
 const log = logger('libp2p:discovery:pubsub')
@@ -35,6 +36,7 @@ export interface PubSubPeerDiscoveryComponents {
   peerId: PeerId
   pubsub?: PubSub
   addressManager: AddressManager
+  registrar: Registrar
 }
 
 /**
@@ -156,7 +158,8 @@ export class PubSubPeerDiscovery extends EventEmitter<PeerDiscoveryEvents> imple
 
     const peer = {
       publicKey: peerId.publicKey,
-      addrs: this.components.addressManager.getAddresses().map(ma => ma.bytes)
+      addrs: this.components.addressManager.getAddresses().map(ma => ma.bytes),
+      protocols: this.components.registrar.getProtocols()
     }
 
     const encodedPeer = PBPeer.encode(peer)
@@ -200,7 +203,7 @@ export class PubSubPeerDiscovery extends EventEmitter<PeerDiscoveryEvents> imple
         detail: {
           id: peerId,
           multiaddrs: peer.addrs.map(b => multiaddr(b)),
-          protocols: []
+          protocols: peer.protocols
         }
       }))
     }).catch(err => {

--- a/src/peer.proto
+++ b/src/peer.proto
@@ -3,4 +3,5 @@ syntax = "proto3";
 message Peer {
   bytes publicKey = 1;
   repeated bytes addrs = 2;
+  repeated string protocols = 3;
 }

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -11,6 +11,7 @@ import type { Uint8ArrayList } from 'uint8arraylist'
 export interface Peer {
   publicKey: Uint8Array
   addrs: Uint8Array[]
+  protocols: string[]
 }
 
 export namespace Peer {
@@ -35,13 +36,21 @@ export namespace Peer {
           }
         }
 
+        if (obj.protocols != null) {
+          for (const value of obj.protocols) {
+            w.uint32(26)
+            w.string(value)
+          }
+        }
+
         if (opts.lengthDelimited !== false) {
           w.ldelim()
         }
       }, (reader, length) => {
         const obj: any = {
           publicKey: new Uint8Array(0),
-          addrs: []
+          addrs: [],
+          protocols: []
         }
 
         const end = length == null ? reader.len : reader.pos + length
@@ -55,6 +64,9 @@ export namespace Peer {
               break
             case 2:
               obj.addrs.push(reader.bytes())
+              break
+            case 3:
+              obj.protocols.push(reader.string())
               break
             default:
               reader.skipType(tag & 7)

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -9,6 +9,7 @@ import { CustomEvent } from '@libp2p/interfaces/events'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import { multiaddr } from '@multiformats/multiaddr'
 import { Peer as PBPeer } from '../src/peer.js'
+import type { Registrar } from '@libp2p/interface-internal/registrar'
 
 describe('compliance tests', () => {
   let intervalId: ReturnType<typeof setInterval>
@@ -25,6 +26,7 @@ describe('compliance tests', () => {
 
       const pubsubDiscovery = pubsubPeerDiscovery()({
         pubsub: stubInterface<PubSub>(),
+        registrar: stubInterface<Registrar>(),
         peerId: await createEd25519PeerId(),
         addressManager
       })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -16,11 +16,13 @@ import { CustomEvent } from '@libp2p/interfaces/events'
 import type { AddressManager } from '@libp2p/interface-address-manager'
 import { start, stop } from '@libp2p/interfaces/startable'
 import type { PeerDiscovery } from '@libp2p/interface-peer-discovery'
+import type { Registrar } from '@libp2p/interface-internal/registrar'
 
 const listeningMultiaddr = multiaddr('/ip4/127.0.0.1/tcp/9000/ws')
 
 describe('PubSub Peer Discovery', () => {
   let mockPubsub: StubbedInstance<PubSub>
+  let mockRegistrar: StubbedInstance<Registrar>
   let discovery: PeerDiscovery
   let components: PubSubPeerDiscoveryComponents
 
@@ -28,6 +30,7 @@ describe('PubSub Peer Discovery', () => {
     const peerId = await createEd25519PeerId()
 
     mockPubsub = stubInterface<PubSub>()
+    mockRegistrar = stubInterface<Registrar>()
 
     const addressManager = stubInterface<AddressManager>()
     addressManager.getAddresses.returns([
@@ -37,6 +40,7 @@ describe('PubSub Peer Discovery', () => {
     components = {
       peerId,
       pubsub: mockPubsub,
+      registrar: mockRegistrar,
       addressManager
     }
   })


### PR DESCRIPTION
The PeerInfo structure emitted by PeerDiscovery includes a 'protocols' field. However, the _broadcast method doesn't send this data and the _onMessage method uses a static empty array. This seems like a missed opportunity to learn a discovered Peer's supported protocols in less round trips.

I've simply updated the PeerInfo structure used by PubSub Peer Discovery to comply to the latest PeerInfo interface and gathered the protocols from the Registrar component. If there is a better place the protocols could be gathered from, that would be easy to change.