### PR TITLE
fix: only emit event when there are topic peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,11 +157,12 @@
     "@libp2p/interface-compliance-tests": "^5.0.5",
     "@libp2p/logger": "^4.0.1",
     "@libp2p/peer-id-factory": "^4.0.0",
+    "@types/sinon": "^17.0.2",
     "aegir": "^41.0.5",
     "p-defer": "^4.0.0",
     "p-wait-for": "^5.0.0",
     "protons": "^7.0.2",
     "sinon": "^17.0.0",
-    "ts-sinon": "^2.0.2"
+    "sinon-ts": "^2.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,11 @@ export class PubSubPeerDiscovery extends TypedEventEmitter<PeerDiscoveryEvents> 
     }
 
     for (const topic of this.topics) {
+      if (pubsub.getSubscribers(topic).length === 0) {
+        this.log('skipping broadcasting our peer data on topic %s because there are no peers present', topic)
+        continue
+      }
+
       this.log('broadcasting our peer data on topic %s', topic)
       void pubsub.publish(topic, encodedPeer)
     }

--- a/test/compliance.spec.ts
+++ b/test/compliance.spec.ts
@@ -5,7 +5,7 @@ import tests from '@libp2p/interface-compliance-tests/peer-discovery'
 import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
-import { stubInterface } from 'ts-sinon'
+import { stubInterface } from 'sinon-ts'
 import { pubsubPeerDiscovery, TOPIC } from '../src/index.js'
 import { Peer as PBPeer } from '../src/peer.js'
 import type { PubSub } from '@libp2p/interface'
@@ -17,6 +17,7 @@ describe('compliance tests', () => {
   tests({
     async setup () {
       const peerId = await createEd25519PeerId()
+      const subscriber = await createEd25519PeerId()
       await new Promise(resolve => setTimeout(resolve, 10))
 
       const addressManager = stubInterface<AddressManager>()
@@ -25,15 +26,21 @@ describe('compliance tests', () => {
       ])
 
       const pubsubDiscovery = pubsubPeerDiscovery()({
-        pubsub: stubInterface<PubSub>(),
-        peerId: await createEd25519PeerId(),
+        pubsub: stubInterface<PubSub>({
+          getSubscribers: () => {
+            return [
+              subscriber
+            ]
+          }
+        }),
+        peerId,
         addressManager,
         logger: defaultLogger()
       })
 
       intervalId = setInterval(() => {
         const peer = PBPeer.encode({
-          publicKey: peerId.publicKey,
+          publicKey: subscriber.publicKey,
           addrs: [
             multiaddr('/ip4/166.10.1.2/tcp/80').bytes
           ]

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -9,7 +9,7 @@ import { expect } from 'aegir/chai'
 import defer from 'p-defer'
 import pWaitFor from 'p-wait-for'
 import sinon from 'sinon'
-import { type StubbedInstance, stubInterface } from 'ts-sinon'
+import { type StubbedInstance, stubInterface } from 'sinon-ts'
 import { pubsubPeerDiscovery, type PubSubPeerDiscoveryComponents, TOPIC } from '../src/index.js'
 import * as PB from '../src/peer.js'
 import type { PeerDiscovery, PeerInfo, PubSub } from '@libp2p/interface'
@@ -24,8 +24,15 @@ describe('PubSub Peer Discovery', () => {
 
   beforeEach(async () => {
     const peerId = await createEd25519PeerId()
+    const subscriber = await createEd25519PeerId()
 
-    mockPubsub = stubInterface<PubSub>()
+    mockPubsub = stubInterface<PubSub>({
+      getSubscribers: () => {
+        return [
+          subscriber
+        ]
+      }
+    })
 
     const addressManager = stubInterface<AddressManager>()
     addressManager.getAddresses.returns([


### PR DESCRIPTION
To prevent gossipsub needing to be configured to publish messages that will go no-where, check that there are topic peers before publishing a message.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works